### PR TITLE
Allow configurable run threshold and trend window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Run Progress Tracker
+
+This project is a single-page tool for tracking run attempts, parts, and sessions.
+Parts are defined by their percentage ranges, and practice runs are scheduled
+automatically from recent part performance using a user‑set probability threshold.
+
+## Structure
+- `index.html` – main interface markup.
+- `style.css` – styles for the interface.
+- `script.js` – logic for data handling, rendering, scheduling, and storage.
+
+Open `index.html` in a browser to use the tracker. Runs are displayed in the Sessions tab and omitted from Trends. The Trends chart can limit displayed batches (default 50) or show all.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Run Progress Tracker</title>
+    <link rel="stylesheet" href="style.css" />
+
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+</head>
+<body>
+  <h1>Run Progress Tracker</h1>
+  <div id="saveFileUI"></div>
+
+  <div id="dayControl" style="display: flex; align-items: center; gap: 8px; margin-top: 10px;">
+    <button onclick="startNewDay()">New Day</button>
+    <button onclick="undoNewDay()">Remove Day</button>
+    <select id="daySelect" onchange="selectDay(this.value)"></select>
+    <select id="viewDaySelect" onchange="renderDayStats(this.value)">
+      <option value="">-- View Day Stats --</option>
+    </select>
+  </div>
+
+  <div id="navTabs" style="margin-top: 10px;">
+    <button onclick="showTab('input')">Run Input</button>
+    <button onclick="showTab('parts')">Parts</button>
+    <button onclick="showTab('sessions')">Sessions</button>
+    <button onclick="showTab('trends')">Trends</button>
+    <button onclick="showTab('logs')">Logs</button>
+  </div>
+
+  <div class="tab-content" id="tab_input">
+    <textarea id="runData" rows="10" placeholder="Enter run data here"></textarea>
+    <button onclick="importRunData()">Import Runs</button>
+  </div>
+
+  <div class="tab-content" id="tab_parts">
+    <input type="number" id="partFrom" placeholder="From (%)" step="any" />
+    <input type="number" id="partTo" placeholder="To (%)" step="any" />
+    <button onclick="addPart()">Add Part</button>
+    <div class="expandable-container">
+      <button class="toggle-btn" onclick="toggleExpand(this)">Expand</button>
+      <div class="part-list" id="partList"></div>
+    </div>
+  </div>
+
+  <div class="tab-content" id="tab_sessions">
+    <div style="margin-bottom:8px;">
+      Run threshold (%): <input type="number" id="runThresholdInput" value="10" step="any" style="width:60px;" />
+    </div>
+    <div style="display:flex; align-items:center; gap:10px; margin-bottom:6px;">
+      <h3 style="margin:0;">Sessions — Overall</h3>
+    </div>
+
+    <div class="expandable-container">
+      <button class="toggle-btn" onclick="toggleExpand(this)">Expand</button>
+      <div style="display:flex; gap:10px;">
+        <div class="stats-list" id="sessionsPartsOverall"></div>
+        <div class="stats-list" id="sessionsRunsOverall"></div>
+      </div>
+    </div>
+
+    <h3>Latest Session</h3>
+    <div class="expandable-container">
+      <button class="toggle-btn" onclick="toggleExpand(this)">Expand</button>
+      <div style="display:flex; gap:10px;">
+        <div class="stats-list" id="sessionsPartsLatest"></div>
+        <div class="stats-list" id="sessionsRunsLatest"></div>
+      </div>
+    </div>
+  </div>
+
+
+
+  <div class="tab-content" id="tab_trends">
+
+    <div style="margin-bottom:8px;">
+      Batches to show: <input type="number" id="trendBatchLimit" value="50" min="1" step="1" style="width:60px;" />
+      <button onclick="setTrendBatchAll()">All</button>
+    </div>
+
+    <h3 style="display:flex;align-items:center;gap:8px;">
+      Trends — Level Chance Over Time
+      <button id="toggleTrendScale">Scale: Log</button>
+    </h3>
+    
+    <div class="expandable-container">
+      <button class="toggle-btn" onclick="toggleExpand(this)">Expand</button>
+      <div style="padding:6px; background:#fff; border:1px solid #ccc;">
+        <canvas id="trendsLevelChart" width="900" height="240"></canvas>
+      </div>
+    </div>
+
+    <h3>Trends — Overall (Current vs Previous)</h3>
+    <div class="expandable-container">
+      <button class="toggle-btn" onclick="toggleExpand(this)">Expand</button>
+      <div style="display:flex; gap:10px;">
+        <div class="stats-list" id="trendsPartsOverall"></div>
+      </div>
+    </div>
+
+    <h3>Trends — Daily (with Comparison)</h3>
+    <div class="expandable-container">
+      <button class="toggle-btn" onclick="toggleExpand(this)">Expand</button>
+      <div style="display:flex; gap:10px;">
+        <div class="stats-list" id="trendsPartsDaily"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="tab-content" id="tab_logs">
+    <h3>Import Log</h3>
+    <div class="expandable-container">
+      <button class="toggle-btn" onclick="toggleExpand(this)">Expand</button>
+      <div class="log-list" id="importLogs"></div>
+    </div>
+  </div>
+
+
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,26 @@
+/* Run Progress Tracker Styles */
+    body { font-family: sans-serif; padding: 10px; font-size: 14px; }
+textarea, input, select { width: 100%; margin-bottom: 6px; padding: 6px; font-size: 14px; }
+.part-item, .stat-item, .log-item, .day-item { margin: 4px 0; padding: 6px; border: 1px solid #ccc; background: #f9f9f9; }
+button { padding: 6px 10px; font-size: 13px; margin-right: 4px; }
+.stats-list, .log-list, .part-list { max-height: 200px; overflow-y: auto; border: 1px solid #ccc; padding: 6px; background: #f4f4f4; }
+.tab-content { display: none; margin-top: 10px; }
+.tab-content.active { display: block; }
+#navTabs button { margin-right: 4px; padding: 6px 10px; }
+.expandable-container {
+  position: relative;
+  margin-bottom: 10px;
+  border: 1px solid #ccc;
+  background: #f4f4f4;
+  padding-top: 26px; /* space for button */
+}
+
+.toggle-btn {
+  position: absolute;
+  top: 2px;
+  right: 6px;
+  font-size: 12px;
+  padding: 2px 6px;
+  cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- remove run goal interface in sessions
- use percent ranges as part labels with decimal support
- add inputs for run probability threshold and trends batch window

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6f10aec788321ae6c11fa9d9a0cad